### PR TITLE
ci: add json validation action on push and pr to main

### DIFF
--- a/.github/workflows/validate-data-json.yml
+++ b/.github/workflows/validate-data-json.yml
@@ -1,0 +1,25 @@
+name: "Validate Substances Data JSON"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+    branches:
+      - main
+    
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate JSON
+        run: cat ./data/final_updated_drugs.json | json_pp
+


### PR DESCRIPTION
## Overview

For contributions to the repo that involve direct changes to the source-of-truth substances data JSON file, larger changes can obfuscate syntax issues that might break the build. (See #7) This PR adds in a continuous integration step that automatically checks for syntax validity of the JSON for every push to main and for every PR to main.

## What was changed?

- created a GitHub actions step that runs a JSON syntax validity check on push and PR to main

## How were these changes tested?

Tested on [fork](https://github.com/a1ts-a1t/SubstanceSearch):

For push to main - 
![image](https://github.com/user-attachments/assets/273a9a9b-0205-4d71-8512-b39cc26a49fc)

For PR against main -
![image](https://github.com/user-attachments/assets/68868874-4e71-4f5d-a4c8-0cafcf4cf84d)

Job working as expected -
![image](https://github.com/user-attachments/assets/def0b050-373d-4c9a-abd7-6e99fe4e52c8)
