### PR TITLE
ci: Replace `json_pp` → `jq`

### DIFF
--- a/.github/workflows/validate-data-json.yml
+++ b/.github/workflows/validate-data-json.yml
@@ -3,7 +3,7 @@ name: "Validate Substances Data JSON"
 on:
   push:
     branches:
-      - '**'
+      - main
     paths:
       - '**.json'
   pull_request:
@@ -12,6 +12,7 @@ on:
       - '**'
     paths:
       - '**.json'
+      - '**.yml'
 
 jobs:
   validate:


### PR DESCRIPTION
`json_pp` is ancient and does not support Unicode nor proper escaping out of the box