### PR TITLE
feat: add issue templates and pr template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,62 @@
+---
+name: Bug Report
+about: Use this template for reporting and tracking bugs.
+labels: bug
+---
+
+## Description
+
+What is the bug?
+
+## Steps to Reproduce
+
+How can we reproduce the bug? Please include any relevant links.
+
+1. Step 1
+2. Step 2
+3. Step 3
+
+## Expected vs Actual Results
+
+What was the expected behavior of the above steps, and what was the actual behavior?
+
+**Expected results:** -
+
+**Actual results:** -
+
+## Priority/Impact
+
+What is the impact of this bug? Please choose from one of the following:
+
+- [ ] High - This bug prevents users from using the site, or the site is presenting substance information that is critically incorrect and could potentially hurt people.
+- [ ] Medium - This bug disrupts normal site usage but is non-breaking, or the site is presenting incorrect substance information that will not hurt people.
+- [ ] Low - This bug does not disrupt site usage.
+
+## Environment
+
+What are the specifications of the environment from which you found the bug? Please fill in the following:
+
+**Source URL:** URL of the page containing the bug
+
+**OS:** Operating System and version (Please note if you're on a mobile system)
+
+**Browser:** Browser information and version (Look for "Help" or "About" in your browser's menu)
+
+**Screen size:** Width x Height of your display (Look for your computer's display settings or look up "screen resolution" and your device model)
+
+## Screenshots and Logs
+
+Please provide any screenshots, screen recordings, or console logs displaying the bug.
+
+## Additional Notes
+
+Is there any other relevant context that developers should know about?
+
+## Checklist
+
+Please address and check off all items prior to submitting this issue:
+
+- [ ] This issue is not a duplicate of [any existing issues](https://github.com/ded-grl/SubstanceSearch/issues).
+- [ ] Substance data inaccuracy reports link to trusted sources with the corrected information in the expected results section.
+- [ ] All sections of this template have been filled out and this bug report has a relevant title.
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,35 @@
+---
+name: Feature Request
+about: Use this template for feature requests.
+labels: enhancement
+---
+
+## Overview
+
+What is the feature you would like to see added to the site? Is there a problem that you're trying to solve?
+
+## Acceptance Criteria
+
+What are the requirements for this enhancement to be considered complete?
+
+It's helpful to think of this in terms of "As a \[specific type of user\], I \[should/must\] be able to \[thing that the feature would enable the user to do\]."
+
+- Acceptance criteria 1
+- Acceptance criteria 2
+- Acceptance criteria 3
+
+## Technical Notes
+
+Are there any technical notes or considerations that would help developers add this feature?
+
+## Additional Notes
+
+Is there any other relevant context that developers should know about?
+
+## Checklist
+
+Please address and check off all items prior to submitting this issue:
+
+- [ ] This issue is not a duplicate of [any existing issues](https://github.com/ded-grl/SubstanceSearch/issues).
+- [ ] All sections of this template have been filled out and this feature request has a relevant title.
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Overview
+
+What's being addresed in this PR? If there are [associated issues](https://github.com/ded-grl/SubstanceSearch/issues), please link to them here.
+
+## Changes
+
+What changes were made in this PR?
+
+* Change 1
+* Change 2
+* Change 3
+
+## Testing
+
+How were these changes tested? Please include relevant testing logs or screenshots/recordings here.
+
+## Additional Notes
+
+Is there any other relevant context that reviewers should know about?.
+
+## Checklist
+
+Please address and check off all items prior to submitting this PR:
+
+- [ ] Changes introduced in this PR are not duplicating changes already made in [another PR](https://github.com/ded-grl/SubstanceSearch/pulls).
+- [ ] Changes to substance data have been validated against trusted sources and is verified to be accurate.
+- [ ] Changes have been tested and logs/screenshots have been recorded and added to the PR description.
+- [ ] All relevant documentation has been updated.
+- [ ] The branch/fork has been rebased against the tip of [the main branch](https://github.com/ded-grl/SubstanceSearch/tree/main).
+- [ ] All sections of this PR template between filled out and this PR has a title.
+- [ ] Relevant reviewers have been tagged to the PR and the correct label has been assigned.
+

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -61,6 +61,7 @@
                     <ul>
                         <li><a href="https://discord.gg/wFPB9xYRBN" rel="noopener" target="_blank">Join our Discord</a></li>
                         <li><a href="/leaderboard">Contributors</a></li>
+                        <li><a href="https://github.com/ded-grl/SubstanceSearch">GitHub</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
## Overview

This PR adds in PR and Issue templates for the repo.

## Changes

What changes were made in this PR?

* Created PR template
* Created bug report and feature request issue templates
* Added link to GH repo on the site

## Testing

- Markdown renders correctly with GH flavored MD (verify by displaying rich diff in the file diffs)
- I'm using the PR template rn

![image](https://github.com/user-attachments/assets/d09b2702-7149-4ae8-bf2c-30e1f920fa17)


## Additional Notes

We should prob have a `CONTRIBUTING.md` but I don't feel totally qualified to write it tbh.

Heads up @ded-grl. This doc's supposed to be one of the first resources contributors see when they want to add to the project. ([Example](https://contributing.md/example/))

## Checklist

Please address and check off all items prior to submitting this PR:

- [x] Changes introduced in this PR are not duplicating changes already made in [another PR](https://github.com/ded-grl/SubstanceSearch/pulls).
- [x] Changes to substance data have been validated against trusted sources and is verified to be accurate.
- [x] Changes have been tested and logs/screenshots have been recorded and added to the PR description.
- [x] All relevant documentation has been updated.
- [x] The branch/fork has been rebased against the tip of [the main branch](https://github.com/ded-grl/SubstanceSearch/tree/main).
- [x] All sections of this PR template between filled out and this PR has a title.
- [x] Relevant reviewers have been tagged to the PR and the correct label has been assigned.