### PR TITLE
Fix theme attribute cookies

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -44,6 +44,8 @@ What are the specifications of the environment from which you found the bug? Ple
 
 **Screen size:** Width x Height of your display (Look for your computer's display settings or look up "screen resolution" and your device model)
 
+**Environment:** [Your local environment](http://localhost:5000), [the staging environment](http://1.stg.substancesearch.com/), or [the production environment](https://substancesearch.com/)
+
 ## Screenshots and Logs
 
 Please provide any screenshots, screen recordings, or console logs displaying the bug.


### PR DESCRIPTION
## Overview

This PR fixes a bug that caused light/dark mode UX to be broken due to misconfigured cookies being sent from the server.

## Changes

* Changed the theme cookie to be sent for every HTML template endpoint if and only if a theme cookie was sent as a part of the request
* Changed the theme cookie to not have the `HttpOnly` attribute, and set `Secure` to depend on the environment (see the TODO)
* Added a view function decorator for theme cookie setting
* Added a note about environments in the bug report template

## Testing

Manual testing with local deployment of the website.


https://github.com/user-attachments/assets/2666fbe2-038f-45e6-9440-6db7ef906ae0

## Additional Notes

Copying in my RCA from `#code-contributions` in the discord:


> ok I found the root cause

>the issue is that we set the response cookie for theme on the home page as HttpOnly. this means that the Theme cookie cannot be read from JS which means that the cookie is not persisted as we would expect 

> the response cookie is only being set like this on the home page endpoint as well, which I think might've made debugging and reproducing a little weirder

> oh and I think i got why this isn't reproducing in the staging environment. the staging environment is served over http (not secure) and is attempting to set the cookie with the Secure flag. the browser sees this and does not set the cookie (https://security.stackexchange.com/a/245624). the browser then sets the cookie itself (in js), which is not http only and reads/writes to that throughout the session as expected

> there's an exception made to this "http responses with secure cookies will not be set" rule for localhost. hence, why we're seeing issues in local even though it's also served through http.

## Checklist

Please address and check off all items prior to submitting this PR:

- [X] Changes introduced in this PR are not duplicating changes already made in [another PR](https://github.com/ded-grl/SubstanceSearch/pulls).
- [X] Changes to substance data have been validated against trusted sources and is verified to be accurate.
- [X] Changes have been tested and logs/screenshots have been recorded and added to the PR description.
- [X] All relevant documentation has been updated.
- [X] The branch/fork has been rebased against the tip of [the main branch](https://github.com/ded-grl/SubstanceSearch/tree/main).
- [X] All sections of this PR template between filled out and this PR has a title.
- [X] Relevant reviewers have been tagged to the PR and the correct label has been assigned.

