### PR TITLE
Fix fetch datamed workflow permissions

### DIFF
--- a/.github/workflows/fetch-datamed-artifact.yml
+++ b/.github/workflows/fetch-datamed-artifact.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ssh-key: ${{secrets.GITHUB_ACTIONS_DEPLOY_KEY}}
         
       - name: Create directories
         run: mkdir -p data/datamed


### PR DESCRIPTION
## Overview

Currently, the workflow to push datamed data to the main branch is [broken due to branch protections set on main](https://github.com/ded-grl/SubstanceSearch/actions/runs/13778004512/job/38530963774#step:5:19). (Even with write permissions enabled for actions, these permissions issues still exist. See the Testing section below)

This change mitigates these protection issues through ruleset bypassing deploy keys, and instructions for setting it up are listed below.

## Changes

What changes were made in this PR?

* Adding in an [SSH key](https://github.com/actions/checkout?tab=readme-ov-file#usage) option for checking out the repo, allowing for permissioned actions to be taken

## Testing

Changes tested in [a fork](https://github.com/a1ts-a1t/SubstanceSearch) by...

1. Recreating [the known issue](https://github.com/a1ts-a1t/SubstanceSearch/actions/runs/13782754977/job/38543877150). We see that the run fails even when actions have write permissions enabled due to rule violations
2. Testing the fix and running [the same action](https://github.com/a1ts-a1t/SubstanceSearch/actions/runs/13782970458/job/38544529886) with the requisite permissions and bypasses configured

## Additional Notes

The code changes are minimal, but there are some more changes to the repo that need to be done to get this to work. (Deferring to a contributor who has the rights to configure these, because I don't think I have the role to do so.) As reference, I followed [this guide](https://stackoverflow.com/a/76135647/21190150). I'll list out the steps here, but please get in touch with me if there are any issues in the setup

1. On your machine (or on a server), run the following command: `ssh-keygen -t ed25519`. You do not need to create a passphrase. Note the name of the file that it's saved in (let's say the file is named `/home/.ssh/id`)
2. In the GitHub repo, navigate to `Settings > Deploy Keys` and click `Add deploy key`.
3. Give the deploy key a title (I used "Actions Write Access") and copy the entire contents of the public key file into the "Key" section. (In our example, this would be the file named `/home/.ssh/id.pub`)
4. In [the ruleset for branch protection for main](https://github.com/ded-grl/SubstanceSearch/rules/3255244?ref=refs%2Fheads%2Fmain), in the "Bypass list" section, click "Add bypass" and check "Deploy keys"
5. Navigate to `Settings > Secrets and variables > Actions` and click "New repository secret". Title it `GITHUB_ACTIONS_DEPLOY_KEY` and in the "Secret" section, copy in the entire contents of the private key file. (In our example, this would be the file named `home/.ssh/id`)

There are [some cons to using deploy keys ](https://stackoverflow.com/a/76135647/21190150) but as far as I can tell, our other options are creating a GH app for this or creating a new user whose purpose is just to make these pushes (or any future automated pushes). Deploy keys seemed suitable for what we're trying to do.

## Checklist

Please address and check off all items prior to submitting this PR:

- [x] Changes introduced in this PR are not duplicating changes already made in [another PR](https://github.com/ded-grl/SubstanceSearch/pulls).
- [x] Changes to substance data have been validated against trusted sources and is verified to be accurate.
- [x] Changes have been tested and logs/screenshots have been recorded and added to the PR description.
- [x] All relevant documentation has been updated.
- [x] The branch/fork has been rebased against the tip of [the main branch](https://github.com/ded-grl/SubstanceSearch/tree/main).
- [x] All sections of this PR template between filled out and this PR has a title.
- [x] Relevant reviewers have been tagged to the PR and the correct label has been assigned.

